### PR TITLE
Fix metarig encoding context for Blender 4.5

### DIFF
--- a/ue2rigify/core/templates.py
+++ b/ue2rigify/core/templates.py
@@ -146,7 +146,7 @@ def get_metarig_data(properties):
         utilities.operator_on_object_in_mode(
             lambda: bpy.ops.armature.rigify_encode_metarig(),
             metarig_object,
-            'EDIT'
+            'OBJECT'
         )
         metarig_text_object = bpy.data.texts.get(os.path.basename(properties.saved_metarig_data))
 


### PR DESCRIPTION
## Summary
- update metarig encoding to run in Object mode for Blender 4.5 compatibility

## Testing
- `pip install -r requirements.txt`
- `pytest -k ue2rigify_core -v` *(fails: expected str, bytes or os.PathLike object, not NoneType)*

------
https://chatgpt.com/codex/tasks/task_e_687cc74e20a083299a08d276fe6066d1